### PR TITLE
Add autoTransport options for self-initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@ var Gossipmonger = module.exports = function Gossipmonger (peerInfo, options) {
     if (!self.transport) {
         var TcpTransport = require('gossipmonger-tcp-transport');
         self.transport = new TcpTransport(self.localPeer.transport);
+    } else {
+        if ( options.autoTransport ) {
+            self.transport = new self.transport(self.localPeer.transport);
+        }
     }
 
     /*


### PR DESCRIPTION
Add a autoTransport option to let gossipmonger initialize a gossipmonger-tcp-transport conform transport with the given transport information automatically.

This is in frame with my gossipmonger-zmq-transport, so that the user can simply write:
`transport: require("gossipmonger-zmq-transport")`
